### PR TITLE
Allow change background (pixelsmith engine)

### DIFF
--- a/bin/spritesmith
+++ b/bin/spritesmith
@@ -35,9 +35,9 @@ function run (data) {
         padding: data.padding || 0,
         exportOpts: {
           format: formats.img.get(data.destImage) || 'png',
-          quality: data.quality || 100
+          quality: data.quality || 100,
+          background: data.background || []
         },
-        engineOpts: data.engineOpts || {},
         cssVarMap: data.cssVarMap,
         cssTemplate: data.cssTemplate,
         cssOpts: data.cssOpts,

--- a/bin/spritesmith
+++ b/bin/spritesmith
@@ -37,6 +37,7 @@ function run (data) {
           format: formats.img.get(data.destImage) || 'png',
           quality: data.quality || 100
         },
+        engineOpts: data.engineOpts || {},
         cssVarMap: data.cssVarMap,
         cssTemplate: data.cssTemplate,
         cssOpts: data.cssOpts,


### PR DESCRIPTION
- Problem: jpg sprites come with black bg by default (this pr allow change bg)
- Solution: we can pass background  to engine (pixelsmith)

Here more info: https://github.com/twolfson/gulp.spritesmith/issues/33

I tested only with pixelsmith engine, have't a lot experiences with node (so need double check before merge =) )